### PR TITLE
Fix Time Calculation for "Past" and "To" Phrases in Word Clock

### DIFF
--- a/wordclockfunctions.ino_english
+++ b/wordclockfunctions.ino_english
@@ -1,5 +1,5 @@
 
-const String clockStringEnglish =  "ITPISKTENNPQUARTERHALFTWENTYUFIVEMINUTESNATOPASTMEAONEFTWONTHREELRFOUREAWFIVEOSIXZUSEVENEIGHTELEVENUNINETWELVETENAWOCLOCK";
+const String clockStringEnglish = "ITPISKTENNPQUARTERHALFTWENTYUFIVEMINUTESNATOPASTMEAONEFTWONTHREELRFOUREAWFIVEOSIXZUSEVENEIGHTELEVENUNINETWELVETENAWOCLOCK";
 
 /**
  * @brief control the four minute indicator LEDs
@@ -7,14 +7,13 @@ const String clockStringEnglish =  "ITPISKTENNPQUARTERHALFTWENTYUFIVEMINUTESNATO
  * @param minutes minutes to be displayed [0 ... 59]
  * @param color 24bit color value
  */
-void drawMinuteIndicator(uint8_t minutes, uint32_t color){
+void drawMinuteIndicator(uint8_t minutes, uint32_t color) {
   //separate LEDs for minutes in an additional row
   {
-  switch (minutes%5)
-    { 
+    switch (minutes % 5) {
       case 0:
         break;
-          
+
       case 1:
         ledmatrix.setMinIndicator(0b1000, color);
         break;
@@ -41,52 +40,51 @@ void drawMinuteIndicator(uint8_t minutes, uint32_t color){
  * @param color 24bit color value
  * @return int: 0 if successful, -1 if sentence not possible to display
  */
-int showStringOnClock(String message, uint32_t color){
-    int messageStart = 0;
-    String word = "";
-    int lastLetterClock = 0;
-    int positionOfWord  = 0;
-    int nextSpace = 0;
-    int index = 0;
+int showStringOnClock(String message, uint32_t color) {
+  int messageStart = 0;
+  String word = "";
+  int lastLetterClock = 0;
+  int positionOfWord = 0;
+  int nextSpace = 0;
+  int index = 0;
 
-    // add space on the end of message for splitting
-    message = message + " ";
+  // add space on the end of message for splitting
+  message = message + " ";
 
-    // empty the targetgrid
-    ledmatrix.gridFlush();
+  // empty the targetgrid
+  ledmatrix.gridFlush();
 
-    while(true){
-      // extract next word from message
-      word = split(message, ' ', index);
-      index++;
-      
-      if(word.length() > 0){
-        // find word in clock string
-        positionOfWord = clockStringEnglish.indexOf(word, lastLetterClock);
-        
-        if(positionOfWord >= 0){
-          // word found on clock -> enable leds in targetgrid
-          for(int i = 0; i < word.length(); i++){
-            int x = (positionOfWord + i)%WIDTH;
-            int y = (positionOfWord + i)/WIDTH;
-            ledmatrix.gridAddPixel(x, y, color);
-          }
-          // remember end of the word on clock
-          lastLetterClock = positionOfWord + word.length();
+  while (true) {
+    // extract next word from message
+    word = split(message, ' ', index);
+    index++;
+
+    if (word.length() > 0) {
+      // find word in clock string
+      positionOfWord = clockStringEnglish.indexOf(word, lastLetterClock);
+
+      if (positionOfWord >= 0) {
+        // word found on clock -> enable leds in targetgrid
+        for (int i = 0; i < word.length(); i++) {
+          int x = (positionOfWord + i) % WIDTH;
+          int y = (positionOfWord + i) / WIDTH;
+          ledmatrix.gridAddPixel(x, y, color);
         }
-        else{
-          // word is not possible to show on clock
-          logger.logString("word is not possible to show on clock: " + String(word));
-          return -1;
-        }
-        //logger.logString(String(nextSpace) + " - " + String());
-      }else{
-        // end - no more word in message
-        break;
+        // remember end of the word on clock
+        lastLetterClock = positionOfWord + word.length();
+      } else {
+        // word is not possible to show on clock
+        logger.logString("word is not possible to show on clock: " + String(word));
+        return -1;
       }
+      //logger.logString(String(nextSpace) + " - " + String());
+    } else {
+      // end - no more word in message
+      break;
     }
-    // return success
-    return 0;
+  }
+  // return success
+  return 0;
 }
 
 /**
@@ -96,127 +94,98 @@ int showStringOnClock(String message, uint32_t color){
  * @param minutes minutes of the time value
  * @return String time as sentence
  */
-String timeToString(uint8_t hours,uint8_t minutes){
+String timeToString(uint8_t hours, uint8_t minutes) {
   Serial.println(hours);
   Serial.println(minutes);
-  
+
   //IT IS
   String message = "IT IS ";
 
-  
+
   //show minutes
-  if(minutes >= 5 && minutes < 10)
-  {
+  if (minutes >= 5 && minutes < 10) {
     message += "FIVE MINUTES ";
-  }
-  else if(minutes >= 10 && minutes < 15)
-  {
+  } else if (minutes >= 10 && minutes < 15) {
     message += "TEN MINUTES ";
-  }
-  else if(minutes >= 15 && minutes < 20)
-  {
+  } else if (minutes >= 15 && minutes < 20) {
     message += "QUARTER ";
-  }
-  else if(minutes >= 20 && minutes < 25)
-  {
-    message += "TWENTY MINUTES "; 
-  }
-  else if(minutes >= 25 && minutes < 30)
-  {
-    message += "TWENTY FIVE MINUTES ";
-  }
-  else if(minutes >= 30 && minutes < 35)
-  {
-    message += "HALF ";
-  }
-  else if(minutes >= 35 && minutes < 40)
-  {
-    message += "TWENTY FIVE MINUTES ";
-  }
-  else if(minutes >= 40 && minutes < 45)
-  {
+  } else if (minutes >= 20 && minutes < 25) {
     message += "TWENTY MINUTES ";
-  }
-  else if(minutes >= 45 && minutes < 50)
-  {
+  } else if (minutes >= 25 && minutes < 30) {
+    message += "TWENTY FIVE MINUTES ";
+  } else if (minutes >= 30 && minutes < 35) {
+    message += "HALF ";
+  } else if (minutes >= 35 && minutes < 40) {
+    message += "TWENTY FIVE MINUTES ";
+  } else if (minutes >= 40 && minutes < 45) {
+    message += "TWENTY MINUTES ";
+  } else if (minutes >= 45 && minutes < 50) {
     message += "QUARTER ";
-  }
-  else if(minutes >= 50 && minutes < 55)
-  {
+  } else if (minutes >= 50 && minutes < 55) {
     message += "TEN MINUTES ";
-  }
-  else if(minutes >= 55 && minutes < 60)
-  {
+  } else if (minutes >= 55 && minutes < 60) {
     message += "FIVE MINUTES ";
   }
 
-  //convert hours to 12h format
-  if(hours >= 12)
-  {
-      hours -= 12;
-  }
-  if(minutes >= 30)
-  {
-      hours++;
-  }
-  if(hours == 12)
-  {
-      hours = 0;
+  // Convert hours to 12h format and adjust for "TO" phrases
+  if (hours >= 12) {
+    hours -= 12;
   }
 
-  if(minutes >= 5 && minutes < 35)
-  {
+  // Increment hour for "TO" phrases (minutes 35 or more)
+  if (minutes >= 35) {
+    hours = (hours + 1) % 12;
+    message += "TO ";
+  } else if (minutes >= 5) {
     message += "PAST ";
   }
-  else if(minutes >= 35 && minutes < 60)
-  {
-    message += "TO ";
-    hours = (hours + 1)%12;
+
+  // Handle edge case for 0 hour (12 AM/PM)
+  if (hours == 0) {
+    hours = 12;
   }
 
   // show hours
-  switch(hours)
-  {
-  case 0:
-    message += "TWELVE ";
-    break;
-  case 1:
-    message += "ONE ";
-    break;
-  case 2:
-    message += "TWO ";
-    break;
-  case 3:
-    message += "THREE ";
-    break;
-  case 4:
-    message += "FOUR ";
-    break;
-  case 5:
-    message += "FIVE ";
-    break;
-  case 6:
-    message += "SIX ";
-    break;
-  case 7:
-    message += "SEVEN ";
-    break;
-  case 8:
-    message += "EIGHT ";
-    break;
-  case 9:
-    message += "NINE ";
-    break;
-  case 10:
-    message += "TEN ";
-    break;
-  case 11:
-    message += "ELEVEN ";
-    break;
+  switch (hours) {
+    case 0:
+      message += "TWELVE ";
+      break;
+    case 1:
+      message += "ONE ";
+      break;
+    case 2:
+      message += "TWO ";
+      break;
+    case 3:
+      message += "THREE ";
+      break;
+    case 4:
+      message += "FOUR ";
+      break;
+    case 5:
+      message += "FIVE ";
+      break;
+    case 6:
+      message += "SIX ";
+      break;
+    case 7:
+      message += "SEVEN ";
+      break;
+    case 8:
+      message += "EIGHT ";
+      break;
+    case 9:
+      message += "NINE ";
+      break;
+    case 10:
+      message += "TEN ";
+      break;
+    case 11:
+      message += "ELEVEN ";
+      break;
   }
 
-  if(minutes < 5)
-  {
+  if (minutes < 5) {
     message += "OCLOCK ";
   }
 
@@ -225,4 +194,3 @@ String timeToString(uint8_t hours,uint8_t minutes){
 
   return message;
 }
-


### PR DESCRIPTION
Issue:
The word clock displays time phrases incorrectly for certain times. 

Specifically:
        "IT IS n TO n" is showing one hour in advance.
        "IT IS HALF PAST n" is showing an hour regressive.

Proposed Solution:
This merge request introduces adjustments to the time calculation logic to address these issues. The changes include:

- Incrementing the hour only when the minutes are 35 or more. This is necessary for correct representation of "to" phrases (e.g., "twenty to eight" should be displayed at 19:40).
- Ensuring the correct handling of the 12-hour format conversion. This involves adjusting the hour incrementation to accurately reflect the transition from AM to PM and vice versa.
- Using "PAST" for minutes between 5 and 34, inclusive. This ensures that times like "half past seven" are displayed correctly (e.g., at 19:30).

These changes aim to ensure that the clock accurately reflects phrases involving "past" and "to," addressing the current issues with hour advancement and regression.