### PR TITLE
Optimize getFormattedTime method with snprintf

### DIFF
--- a/ntp_client_plus.cpp
+++ b/ntp_client_plus.cpp
@@ -200,15 +200,14 @@ int NTPClientPlus::getSeconds() const
 String NTPClientPlus::getFormattedTime() const {
   unsigned long rawTime = this->getEpochTime();
   unsigned long hours = (rawTime % 86400L) / 3600;
-  String hoursStr = hours < 10 ? "0" + String(hours) : String(hours);
-
   unsigned long minutes = (rawTime % 3600) / 60;
-  String minuteStr = minutes < 10 ? "0" + String(minutes) : String(minutes);
-
   unsigned long seconds = rawTime % 60;
-  String secondStr = seconds < 10 ? "0" + String(seconds) : String(seconds);
 
-  return hoursStr + ":" + minuteStr + ":" + secondStr;
+  // Fester Puffer statt mehrfacher String-Verkettung, um Heap-Fragmentierung zu vermeiden
+  // Format identisch zu vorher: hh:mm:ss (jeweils 2-stellig, mit fuehrender Null)
+  char buffer[9]; // "hh:mm:ss" + '\0'
+  snprintf(buffer, sizeof(buffer), "%02lu:%02lu:%02lu", hours, minutes, seconds);
+  return String(buffer);
 }
 
 /**


### PR DESCRIPTION
Refactor time formatting to use snprintf for efficiency and avoid heap fragmentation.

The original builds 4 separate String objects (hoursStr, minuteStr, secondStr + the final concatenation), my version builds only a single String at the very end – everything else happens in the fixed char buffer on the stack, with no heap allocations. Output format (e.g. "09:05:03") is identical. no need to change anything in ntp_client_plus.h