### PR TITLE
Refactor logString method for efficiency

### DIFF
--- a/udplogger.cpp
+++ b/udplogger.cpp
@@ -16,15 +16,16 @@ void UDPLogger::setName(String name){
     _name = name;
 }
 
-void UDPLogger::logString(String logmessage){
+void UDPLogger::logString(const String& logmessage){
     // wait 5 milliseconds if last send was less than 5 milliseconds before 
     if(millis() < (_lastSend + 5)){
         delay(5);
     }
-    logmessage = _name + ": " + logmessage;
-    Serial.println(logmessage);
+    // Fester Puffer statt String-Verkettung, um Heap-Fragmentierung zu vermeiden
+    // (identisches Format und identische Kuerzung bei 100 Zeichen wie vorher)
+    snprintf(_packetBuffer, sizeof(_packetBuffer), "%s: %s", _name.c_str(), logmessage.c_str());
+    Serial.println(_packetBuffer);
     _Udp.beginPacketMulticast(_multicastAddr, _port, _interfaceAddr);
-    logmessage.toCharArray(_packetBuffer, 100);
     _Udp.print(_packetBuffer);
     _Udp.endPacket();
     _lastSend=millis();


### PR DESCRIPTION
Refactor logString to use snprintf for better performance and avoid heap fragmentation. The problem: `logString()` takes the String by copy (not `const String&`), AND internally builds yet another new string on top of that. So every single log call causes multiple heap allocations/deallocations instead of just one.
(Internal concatenation → snprintf into existing fixed buffer)

The fatal part: this logger gets triggered automatically every 30 seconds – on every NTP update:
